### PR TITLE
Change bash usage for lab1 scripts

### DIFF
--- a/labs/lab1/answers.txt
+++ b/labs/lab1/answers.txt
@@ -1,11 +1,11 @@
-#/bin/bash
+#!/usr/bin/env bash
 
 # CS190 Lab2 Answer Sheet
 
 # NOTE: Ignore the line directly below any "# ignore" statement.
 
 # ignore
-cd; curl -sL https://raw.githubusercontent.com/PurdueCS190/lab1/master/lab1init | /bin/bash
+cd; curl -sL https://raw.githubusercontent.com/PurdueCS190/lab1/master/lab1init | bash
 
 # ignore
 cd ~/cs190lab1

--- a/labs/lab1/lab1init
+++ b/labs/lab1/lab1init
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 
 # clean slate
 rm -rf ~/cs190lab1


### PR DESCRIPTION
* Change shebang from /bin/bash to /usr/bin/env bash
* Update shebang notation with #!
* Replace /bin/bash with 'bash' to use general system command

/bin/bash doesn't work on all systems
I get warning/errors if i try to run when bash is in /usr/local/bin
replacing /bin/bash with just 'bash' removes warning when piping magic script