### PR TITLE
Fix path to lab1init in answers.txt

### DIFF
--- a/labs/lab1/answers.txt
+++ b/labs/lab1/answers.txt
@@ -5,7 +5,7 @@
 # NOTE: Ignore the line directly below any "# ignore" statement.
 
 # ignore
-cd; curl -sL https://raw.githubusercontent.com/PurdueCS190/lab1/master/lab1init | bash
+cd; curl -sL https://raw.githubusercontent.com/Purdue-CSUSB/CSToolsCourse/master/labs/lab1/lab1init | bash
 
 # ignore
 cd ~/cs190lab1


### PR DESCRIPTION
Answers.txt resets by running the "magic command", however the raw URL to the init script is outdated, causing an error "Not: command not found" due to the "Not Found" response from GitHub. Update the URL.

Signed-off-by: Christian Stewart \<christian@paral.in\>