### PR TITLE
Lab2: Add quit preference text to README

### DIFF
--- a/labs/lab2/README.md
+++ b/labs/lab2/README.md
@@ -157,6 +157,8 @@ First you need to get the DrJava source code. Run:
     ```
 
 7. Quit DrJava to see your new message!
+    * You might have to enable the "Prompt Before Quit" option.
+    * Check Edit > Preferences > Notifications > "Prompt Before Quit"
 
 
 ## Grading ##


### PR DESCRIPTION
The quit prompt might not be enabled.
Add the path to the option for reference, in case the option isn't checked