### PR TITLE
Get rid of asterisks around line number in vim

### DIFF
--- a/labs/lab4/lecture04-vim-sublime.md
+++ b/labs/lab4/lecture04-vim-sublime.md
@@ -48,7 +48,7 @@ To save and exit files, you must be in command mode (click esc). You must type t
 - **dw** &nbsp;&nbsp;will delete the word to the right of the cursor
 - ***n* dw** &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;will delete ***n*** words to the right of the cursor
 - **x** &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;will delete letter highlighted by the cursor 
-- **:*n*** &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;go to the ***n***th line in the file.
+- **:n** &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;go to the ***n***th line in the file.
 
 ### Sublime Text
 


### PR DESCRIPTION
I've already had a few kids confused about this one.